### PR TITLE
Add --list flag to show available skills

### DIFF
--- a/cmd/skillet/main_test.go
+++ b/cmd/skillet/main_test.go
@@ -362,6 +362,12 @@ func TestSeparateFlags_QuietFlag(t *testing.T) {
 			expectedFlags:   []string{"--color=always"},
 			expectedPosArgs: []string{"skill-name"},
 		},
+		{
+			name:            "list flag",
+			args:            []string{"--list"},
+			expectedFlags:   []string{"--list"},
+			expectedPosArgs: []string{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -388,5 +394,35 @@ func TestSeparateFlags_QuietFlag(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRun_List(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	err := run([]string{"skillet", "--list"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	// Should show the "Available Skills" header
+	if !strings.Contains(output, "Available Skills") {
+		t.Errorf("List output should contain 'Available Skills', got: %s", output)
+	}
+}
+
+func TestRun_List_WithColorNever(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	err := run([]string{"skillet", "--list", "--color=never"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	// Should show the "Available Skills" header
+	if !strings.Contains(output, "Available Skills") {
+		t.Errorf("List output should contain 'Available Skills', got: %s", output)
 	}
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,0 +1,183 @@
+// Package discovery provides skill discovery functionality.
+// It can find all available skills across multiple search paths,
+// with support for precedence and detecting overshadowed skills.
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/martinemde/skillet/internal/skillpath"
+)
+
+// Skill represents a discovered skill
+type Skill struct {
+	// Name is the skill name (directory name)
+	Name string
+	// Path is the absolute path to the SKILL.md file
+	Path string
+	// Source is information about where this skill was found
+	Source skillpath.Source
+	// Overshadowed indicates this skill is hidden by a higher-priority skill
+	Overshadowed bool
+	// OvershadowedBy is the path of the skill that shadows this one
+	OvershadowedBy string
+}
+
+// Finder is an interface for finding skills in a source directory.
+// This allows for different discovery strategies (e.g., directory pattern,
+// registry lookup, etc.)
+type Finder interface {
+	// Find discovers skills in the given source directory.
+	// It returns a list of skills found, without considering precedence.
+	Find(source skillpath.Source) ([]Skill, error)
+}
+
+// DirectoryFinder finds skills using the standard directory pattern:
+// {source}/skills/{name}/SKILL.md
+type DirectoryFinder struct{}
+
+// Find discovers skills in the given source using the directory pattern
+func (f *DirectoryFinder) Find(source skillpath.Source) ([]Skill, error) {
+	var skills []Skill
+
+	// Check if the source directory exists
+	if _, err := os.Stat(source.Path); os.IsNotExist(err) {
+		return skills, nil
+	}
+
+	// Read the source directory
+	entries, err := os.ReadDir(source.Path)
+	if err != nil {
+		// If we can't read the directory, just return empty
+		return skills, nil
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		skillName := entry.Name()
+		skillPath := skillpath.SkillPath(source.Path, skillName)
+
+		// Check if SKILL.md exists
+		if _, err := os.Stat(skillPath); err == nil {
+			skills = append(skills, Skill{
+				Name:   skillName,
+				Path:   skillPath,
+				Source: source,
+			})
+		}
+	}
+
+	return skills, nil
+}
+
+// Discoverer finds all available skills across a skill path
+type Discoverer struct {
+	path   *skillpath.Path
+	finder Finder
+}
+
+// New creates a new Discoverer with the default finder
+func New(path *skillpath.Path) *Discoverer {
+	return &Discoverer{
+		path:   path,
+		finder: &DirectoryFinder{},
+	}
+}
+
+// NewWithFinder creates a new Discoverer with a custom finder
+func NewWithFinder(path *skillpath.Path, finder Finder) *Discoverer {
+	return &Discoverer{
+		path:   path,
+		finder: finder,
+	}
+}
+
+// Discover finds all skills across all sources in the path.
+// Skills are returned sorted by precedence (source priority), then alphabetically.
+// Skills that are overshadowed by higher-priority sources are marked as such.
+func (d *Discoverer) Discover() ([]Skill, error) {
+	// Track skills we've seen (by name) and their paths
+	seen := make(map[string]string) // name -> path of highest-priority version
+	var allSkills []Skill
+
+	// Iterate through sources in priority order
+	sources := d.path.Sources()
+	for _, source := range sources {
+		skills, err := d.finder.Find(source)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, skill := range skills {
+			if existingPath, exists := seen[skill.Name]; exists {
+				// This skill is overshadowed
+				skill.Overshadowed = true
+				skill.OvershadowedBy = existingPath
+			} else {
+				// First time seeing this skill
+				seen[skill.Name] = skill.Path
+			}
+			allSkills = append(allSkills, skill)
+		}
+	}
+
+	// Sort: by source priority, then alphabetically by name
+	sort.Slice(allSkills, func(i, j int) bool {
+		if allSkills[i].Source.Priority != allSkills[j].Source.Priority {
+			return allSkills[i].Source.Priority < allSkills[j].Source.Priority
+		}
+		return allSkills[i].Name < allSkills[j].Name
+	})
+
+	return allSkills, nil
+}
+
+// DiscoverByName finds all versions of a skill with the given name across all sources.
+// This is useful for debugging to see all locations where a skill is defined.
+func (d *Discoverer) DiscoverByName(name string) ([]Skill, error) {
+	allSkills, err := d.Discover()
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []Skill
+	for _, skill := range allSkills {
+		if skill.Name == name {
+			matches = append(matches, skill)
+		}
+	}
+	return matches, nil
+}
+
+// RelativePath returns a display-friendly relative path for the skill.
+// It tries to make the path relative to common reference points.
+func RelativePath(skill Skill) string {
+	// Try to make relative to home directory
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		if rel, err := filepath.Rel(homeDir, skill.Path); err == nil {
+			if len(rel) < len(skill.Path) {
+				return "~/" + rel
+			}
+		}
+	}
+
+	// Try to make relative to current directory
+	wd, err := os.Getwd()
+	if err == nil {
+		if rel, err := filepath.Rel(wd, skill.Path); err == nil {
+			if len(rel) < len(skill.Path) && rel[0] != '.' {
+				return "./" + rel
+			} else if len(rel) < len(skill.Path) {
+				return rel
+			}
+		}
+	}
+
+	return skill.Path
+}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,0 +1,387 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/martinemde/skillet/internal/skillpath"
+)
+
+// createSkillDir creates a skill directory with SKILL.md file
+func createSkillDir(t *testing.T, baseDir, skillName string) string {
+	t.Helper()
+	skillDir := filepath.Join(baseDir, skillName)
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("failed to create skill directory: %v", err)
+	}
+	skillFile := filepath.Join(skillDir, skillpath.SkillFile)
+	if err := os.WriteFile(skillFile, []byte("test content"), 0644); err != nil {
+		t.Fatalf("failed to create skill file: %v", err)
+	}
+	return skillDir
+}
+
+func TestDirectoryFinder_Find(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillsDir := filepath.Join(tmpDir, skillpath.ClaudeDir, skillpath.SkillsDir)
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatalf("failed to create skills directory: %v", err)
+	}
+
+	// Create some test skills
+	createSkillDir(t, skillsDir, "alpha-skill")
+	createSkillDir(t, skillsDir, "beta-skill")
+	createSkillDir(t, skillsDir, "gamma-skill")
+
+	// Create a non-skill directory (no SKILL.md)
+	nonSkillDir := filepath.Join(skillsDir, "not-a-skill")
+	if err := os.MkdirAll(nonSkillDir, 0755); err != nil {
+		t.Fatalf("failed to create non-skill directory: %v", err)
+	}
+
+	// Create a file (not a directory)
+	if err := os.WriteFile(filepath.Join(skillsDir, "random-file.txt"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	finder := &DirectoryFinder{}
+	source := skillpath.Source{
+		Path:     skillsDir,
+		Name:     "test",
+		Priority: 0,
+	}
+
+	skills, err := finder.Find(source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(skills) != 3 {
+		t.Errorf("expected 3 skills, got %d", len(skills))
+	}
+
+	// Check that all expected skills were found
+	foundSkills := make(map[string]bool)
+	for _, skill := range skills {
+		foundSkills[skill.Name] = true
+	}
+
+	for _, expected := range []string{"alpha-skill", "beta-skill", "gamma-skill"} {
+		if !foundSkills[expected] {
+			t.Errorf("expected to find skill %s", expected)
+		}
+	}
+
+	// Should not have found non-skill directory or file
+	if foundSkills["not-a-skill"] {
+		t.Error("should not have found non-skill directory")
+	}
+	if foundSkills["random-file.txt"] {
+		t.Error("should not have found file as skill")
+	}
+}
+
+func TestDirectoryFinder_Find_EmptyDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillsDir := filepath.Join(tmpDir, skillpath.ClaudeDir, skillpath.SkillsDir)
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatalf("failed to create skills directory: %v", err)
+	}
+
+	finder := &DirectoryFinder{}
+	source := skillpath.Source{
+		Path:     skillsDir,
+		Name:     "test",
+		Priority: 0,
+	}
+
+	skills, err := finder.Find(source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(skills) != 0 {
+		t.Errorf("expected 0 skills, got %d", len(skills))
+	}
+}
+
+func TestDirectoryFinder_Find_NonExistentDirectory(t *testing.T) {
+	finder := &DirectoryFinder{}
+	source := skillpath.Source{
+		Path:     "/non/existent/path",
+		Name:     "test",
+		Priority: 0,
+	}
+
+	skills, err := finder.Find(source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(skills) != 0 {
+		t.Errorf("expected 0 skills for non-existent directory, got %d", len(skills))
+	}
+}
+
+func TestDiscoverer_Discover(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create project-scoped skills
+	projectSkillsDir := filepath.Join(tmpDir, "project", skillpath.ClaudeDir, skillpath.SkillsDir)
+	if err := os.MkdirAll(projectSkillsDir, 0755); err != nil {
+		t.Fatalf("failed to create project skills directory: %v", err)
+	}
+	createSkillDir(t, projectSkillsDir, "common-skill")
+	createSkillDir(t, projectSkillsDir, "project-only")
+
+	// Create user-scoped skills
+	userSkillsDir := filepath.Join(tmpDir, "user", skillpath.ClaudeDir, skillpath.SkillsDir)
+	if err := os.MkdirAll(userSkillsDir, 0755); err != nil {
+		t.Fatalf("failed to create user skills directory: %v", err)
+	}
+	createSkillDir(t, userSkillsDir, "common-skill") // This should be overshadowed
+	createSkillDir(t, userSkillsDir, "user-only")
+
+	// Create custom sources
+	sources := []skillpath.Source{
+		{Path: projectSkillsDir, Name: "project", Priority: 0},
+		{Path: userSkillsDir, Name: "user", Priority: 1},
+	}
+	path := skillpath.NewWithSources(sources)
+	disc := New(path)
+
+	skills, err := disc.Discover()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(skills) != 4 {
+		t.Errorf("expected 4 skills, got %d", len(skills))
+	}
+
+	// Verify ordering (by priority, then alphabetically)
+	expectedOrder := []string{"common-skill", "project-only", "common-skill", "user-only"}
+	for i, skill := range skills {
+		if skill.Name != expectedOrder[i] {
+			t.Errorf("expected skill %d to be %s, got %s", i, expectedOrder[i], skill.Name)
+		}
+	}
+
+	// Check overshadowed status
+	for _, skill := range skills {
+		if skill.Name == "common-skill" {
+			if skill.Source.Name == "user" && !skill.Overshadowed {
+				t.Error("expected user common-skill to be overshadowed")
+			}
+			if skill.Source.Name == "project" && skill.Overshadowed {
+				t.Error("expected project common-skill to not be overshadowed")
+			}
+		}
+	}
+}
+
+func TestDiscoverer_Discover_Sorting(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create skills in non-alphabetical order
+	skillsDir := filepath.Join(tmpDir, skillpath.ClaudeDir, skillpath.SkillsDir)
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatalf("failed to create skills directory: %v", err)
+	}
+
+	createSkillDir(t, skillsDir, "zebra")
+	createSkillDir(t, skillsDir, "alpha")
+	createSkillDir(t, skillsDir, "middle")
+
+	sources := []skillpath.Source{
+		{Path: skillsDir, Name: "test", Priority: 0},
+	}
+	path := skillpath.NewWithSources(sources)
+	disc := New(path)
+
+	skills, err := disc.Discover()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be sorted alphabetically within the same priority
+	expectedOrder := []string{"alpha", "middle", "zebra"}
+	for i, skill := range skills {
+		if skill.Name != expectedOrder[i] {
+			t.Errorf("expected skill %d to be %s, got %s", i, expectedOrder[i], skill.Name)
+		}
+	}
+}
+
+func TestDiscoverer_DiscoverByName(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create skills in two sources
+	source1Dir := filepath.Join(tmpDir, "source1")
+	source2Dir := filepath.Join(tmpDir, "source2")
+	if err := os.MkdirAll(source1Dir, 0755); err != nil {
+		t.Fatalf("failed to create source1 directory: %v", err)
+	}
+	if err := os.MkdirAll(source2Dir, 0755); err != nil {
+		t.Fatalf("failed to create source2 directory: %v", err)
+	}
+
+	createSkillDir(t, source1Dir, "target-skill")
+	createSkillDir(t, source1Dir, "other-skill")
+	createSkillDir(t, source2Dir, "target-skill")
+
+	sources := []skillpath.Source{
+		{Path: source1Dir, Name: "source1", Priority: 0},
+		{Path: source2Dir, Name: "source2", Priority: 1},
+	}
+	path := skillpath.NewWithSources(sources)
+	disc := New(path)
+
+	skills, err := disc.DiscoverByName("target-skill")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(skills) != 2 {
+		t.Errorf("expected 2 skills, got %d", len(skills))
+	}
+
+	// First should be from source1, second from source2
+	if skills[0].Source.Name != "source1" {
+		t.Errorf("expected first skill to be from source1, got %s", skills[0].Source.Name)
+	}
+	if skills[1].Source.Name != "source2" {
+		t.Errorf("expected second skill to be from source2, got %s", skills[1].Source.Name)
+	}
+
+	// Second should be overshadowed
+	if !skills[1].Overshadowed {
+		t.Error("expected second skill to be overshadowed")
+	}
+}
+
+func TestRelativePath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("could not get home directory")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Skip("could not get working directory")
+	}
+
+	tests := []struct {
+		name     string
+		skill    Skill
+		contains string
+	}{
+		{
+			name: "home directory path",
+			skill: Skill{
+				Path: filepath.Join(homeDir, ".claude", "skills", "test", "SKILL.md"),
+			},
+			contains: "~",
+		},
+		{
+			name: "working directory path",
+			skill: Skill{
+				Path: filepath.Join(wd, ".claude", "skills", "test", "SKILL.md"),
+			},
+			contains: ".claude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RelativePath(tt.skill)
+			if len(result) == 0 {
+				t.Error("expected non-empty result")
+			}
+			// The result should be shorter or equal to the original path
+			// (unless there's no good relative path available)
+		})
+	}
+}
+
+// MockFinder is a custom finder for testing the Finder interface
+type MockFinder struct {
+	skills []Skill
+	err    error
+}
+
+func (f *MockFinder) Find(_ skillpath.Source) ([]Skill, error) {
+	return f.skills, f.err
+}
+
+func TestNewWithFinder(t *testing.T) {
+	mockSkills := []Skill{
+		{Name: "mock-skill-1"},
+		{Name: "mock-skill-2"},
+	}
+	mockFinder := &MockFinder{skills: mockSkills}
+
+	sources := []skillpath.Source{
+		{Path: "/test", Name: "test", Priority: 0},
+	}
+	path := skillpath.NewWithSources(sources)
+	disc := NewWithFinder(path, mockFinder)
+
+	skills, err := disc.Discover()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(skills) != 2 {
+		t.Errorf("expected 2 skills from mock finder, got %d", len(skills))
+	}
+}
+
+func TestDiscoverer_OvershadowedBy(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create the same skill in two sources
+	source1Dir := filepath.Join(tmpDir, "source1")
+	source2Dir := filepath.Join(tmpDir, "source2")
+	if err := os.MkdirAll(source1Dir, 0755); err != nil {
+		t.Fatalf("failed to create source1 directory: %v", err)
+	}
+	if err := os.MkdirAll(source2Dir, 0755); err != nil {
+		t.Fatalf("failed to create source2 directory: %v", err)
+	}
+
+	createSkillDir(t, source1Dir, "shared-skill")
+	createSkillDir(t, source2Dir, "shared-skill")
+
+	sources := []skillpath.Source{
+		{Path: source1Dir, Name: "high-priority", Priority: 0},
+		{Path: source2Dir, Name: "low-priority", Priority: 1},
+	}
+	path := skillpath.NewWithSources(sources)
+	disc := New(path)
+
+	skills, err := disc.Discover()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the overshadowed skill
+	var overshadowed *Skill
+	for i := range skills {
+		if skills[i].Overshadowed {
+			overshadowed = &skills[i]
+			break
+		}
+	}
+
+	if overshadowed == nil {
+		t.Fatal("expected to find an overshadowed skill")
+	}
+
+	// OvershadowedBy should point to the higher priority skill's path
+	expectedPath := filepath.Join(source1Dir, "shared-skill", skillpath.SkillFile)
+	if overshadowed.OvershadowedBy != expectedPath {
+		t.Errorf("expected OvershadowedBy to be %s, got %s", expectedPath, overshadowed.OvershadowedBy)
+	}
+}

--- a/internal/skillpath/skillpath.go
+++ b/internal/skillpath/skillpath.go
@@ -1,0 +1,93 @@
+// Package skillpath defines the search path for finding skills.
+// The path is a list of directories where skills can be found,
+// similar to a shell PATH. Skills are looked up in each directory
+// in order, with earlier directories taking precedence.
+package skillpath
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	// ClaudeDir is the name of the Claude configuration directory
+	ClaudeDir = ".claude"
+	// SkillsDir is the subdirectory within ClaudeDir that contains skills
+	SkillsDir = "skills"
+	// SkillFile is the filename for skill definitions
+	SkillFile = "SKILL.md"
+)
+
+// Source represents a location where skills can be found
+type Source struct {
+	// Path is the absolute path to the skills directory
+	Path string
+	// Name is a human-readable name for this source (e.g., "project", "user")
+	Name string
+	// Priority determines precedence (lower numbers = higher priority)
+	Priority int
+}
+
+// Path represents a list of sources to search for skills
+type Path struct {
+	sources []Source
+}
+
+// New creates a new skill path with the default sources:
+// 1. Project-scoped: .claude/skills in working directory (priority 0)
+// 2. User-scoped: ~/.claude/skills (priority 1)
+func New() (*Path, error) {
+	return NewWithWorkDir("")
+}
+
+// NewWithWorkDir creates a new skill path with a specific working directory.
+// If workDir is empty, the current working directory is used.
+func NewWithWorkDir(workDir string) (*Path, error) {
+	if workDir == "" {
+		var err error
+		workDir, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var sources []Source
+
+	// Add project-scoped source (working directory)
+	projectPath := filepath.Join(workDir, ClaudeDir, SkillsDir)
+	sources = append(sources, Source{
+		Path:     projectPath,
+		Name:     "project",
+		Priority: 0,
+	})
+
+	// Add user-scoped source (home directory)
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		userPath := filepath.Join(homeDir, ClaudeDir, SkillsDir)
+		sources = append(sources, Source{
+			Path:     userPath,
+			Name:     "user",
+			Priority: 1,
+		})
+	}
+
+	return &Path{sources: sources}, nil
+}
+
+// NewWithSources creates a Path with custom sources.
+// This is useful for testing or custom configurations.
+func NewWithSources(sources []Source) *Path {
+	return &Path{sources: sources}
+}
+
+// Sources returns the list of sources in this path
+func (p *Path) Sources() []Source {
+	return p.sources
+}
+
+// SkillPath returns the expected path for a skill with the given name
+// in the given source directory.
+func SkillPath(sourceDir, skillName string) string {
+	return filepath.Join(sourceDir, skillName, SkillFile)
+}

--- a/internal/skillpath/skillpath_test.go
+++ b/internal/skillpath/skillpath_test.go
@@ -1,0 +1,159 @@
+package skillpath
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	path, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sources := path.Sources()
+	if len(sources) < 1 {
+		t.Fatal("expected at least one source")
+	}
+
+	// First source should be project-scoped
+	if sources[0].Name != "project" {
+		t.Errorf("expected first source name to be 'project', got %s", sources[0].Name)
+	}
+	if sources[0].Priority != 0 {
+		t.Errorf("expected first source priority to be 0, got %d", sources[0].Priority)
+	}
+	if !strings.HasSuffix(sources[0].Path, filepath.Join(ClaudeDir, SkillsDir)) {
+		t.Errorf("expected first source path to end with %s, got %s", filepath.Join(ClaudeDir, SkillsDir), sources[0].Path)
+	}
+
+	// Second source should be user-scoped (if home directory is available)
+	if len(sources) >= 2 {
+		if sources[1].Name != "user" {
+			t.Errorf("expected second source name to be 'user', got %s", sources[1].Name)
+		}
+		if sources[1].Priority != 1 {
+			t.Errorf("expected second source priority to be 1, got %d", sources[1].Priority)
+		}
+	}
+}
+
+func TestNewWithWorkDir(t *testing.T) {
+	workDir := t.TempDir()
+
+	path, err := NewWithWorkDir(workDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sources := path.Sources()
+	if len(sources) < 1 {
+		t.Fatal("expected at least one source")
+	}
+
+	expectedPath := filepath.Join(workDir, ClaudeDir, SkillsDir)
+	if sources[0].Path != expectedPath {
+		t.Errorf("expected first source path to be %s, got %s", expectedPath, sources[0].Path)
+	}
+}
+
+func TestNewWithSources(t *testing.T) {
+	customSources := []Source{
+		{Path: "/custom/path1", Name: "custom1", Priority: 0},
+		{Path: "/custom/path2", Name: "custom2", Priority: 1},
+	}
+
+	path := NewWithSources(customSources)
+	sources := path.Sources()
+
+	if len(sources) != 2 {
+		t.Fatalf("expected 2 sources, got %d", len(sources))
+	}
+
+	if sources[0].Path != "/custom/path1" {
+		t.Errorf("expected first source path to be /custom/path1, got %s", sources[0].Path)
+	}
+	if sources[1].Path != "/custom/path2" {
+		t.Errorf("expected second source path to be /custom/path2, got %s", sources[1].Path)
+	}
+}
+
+func TestSkillPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		sourceDir string
+		skillName string
+		expected  string
+	}{
+		{
+			name:      "simple path",
+			sourceDir: "/home/user/.claude/skills",
+			skillName: "my-skill",
+			expected:  "/home/user/.claude/skills/my-skill/SKILL.md",
+		},
+		{
+			name:      "relative path",
+			sourceDir: ".claude/skills",
+			skillName: "test-skill",
+			expected:  ".claude/skills/test-skill/SKILL.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SkillPath(tt.sourceDir, tt.skillName)
+			// Normalize paths for comparison on different OS
+			expected := filepath.FromSlash(tt.expected)
+			if result != expected {
+				t.Errorf("expected %s, got %s", expected, result)
+			}
+		})
+	}
+}
+
+func TestSourcePriority(t *testing.T) {
+	path, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sources := path.Sources()
+
+	// Verify priorities are in order
+	for i := 1; i < len(sources); i++ {
+		if sources[i].Priority <= sources[i-1].Priority {
+			// Allow equal priorities within the same tier, but lower priority sources
+			// should have higher priority numbers
+			if sources[i].Priority < sources[i-1].Priority {
+				t.Errorf("expected priorities to be in ascending order, but source %d has priority %d and source %d has priority %d",
+					i-1, sources[i-1].Priority, i, sources[i].Priority)
+			}
+		}
+	}
+}
+
+func TestNewWithWorkDir_EmptyString(t *testing.T) {
+	// When workDir is empty, it should use current working directory
+	path, err := NewWithWorkDir("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sources := path.Sources()
+	if len(sources) < 1 {
+		t.Fatal("expected at least one source")
+	}
+
+	// Should match current working directory
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	expectedPath := filepath.Join(wd, ClaudeDir, SkillsDir)
+	if sources[0].Path != expectedPath {
+		t.Errorf("expected first source path to be %s, got %s", expectedPath, sources[0].Path)
+	}
+}


### PR DESCRIPTION
Implement skill discovery with a path-based lookup system:

- Add skillpath package: defines search paths for skills (project .claude/skills
  then user ~/.claude/skills) with priority-based precedence
- Add discovery package: modular skill discovery with a Finder interface to
  allow future extensibility for different lookup strategies
- Add --list flag: displays all available skills with nice formatting using
  lipgloss, showing overshadowed skills with strikethrough styling
- Skills are sorted by precedence (source priority), then alphabetically

The design allows for adding other ways to find skills beyond the standard
directory pattern (skills/{name}/SKILL.md) by implementing the Finder interface.