### PR TITLE
Fix --color=always for piped output

### DIFF
--- a/cmd/skillet/main.go
+++ b/cmd/skillet/main.go
@@ -143,6 +143,9 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
+	// Configure global color profile early, before any rendering
+	color.ConfigureColorProfile(*colorFlag)
+
 	if *showVersion {
 		_, _ = fmt.Fprintf(stdout, "skillet version %s\n", version)
 		return nil

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,6 +1,11 @@
 package color
 
-import "os"
+import (
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
 
 // ShouldUseColors determines if colors should be used based on the color setting
 func ShouldUseColors(colorMode string) bool {
@@ -21,5 +26,27 @@ func ShouldUseColors(colorMode string) bool {
 		return false
 	default:
 		return true // Default to colors
+	}
+}
+
+// ConfigureColorProfile sets the global lipgloss color profile based on the color mode.
+// This must be called early before any lipgloss/glamour rendering to ensure colors
+// are properly enabled or disabled when output is piped.
+//
+// For "always": Forces TrueColor profile to enable full color support regardless of
+// TTY status. This allows colors to work in piped output (e.g., fzf preview).
+//
+// For "never": Forces Ascii profile which disables all colors.
+//
+// For "auto": Does nothing, letting lipgloss use its default TTY-based detection.
+func ConfigureColorProfile(colorMode string) {
+	switch colorMode {
+	case "always":
+		// Force TrueColor when user explicitly requests colors
+		// This bypasses TTY detection entirely
+		lipgloss.SetColorProfile(termenv.TrueColor)
+	case "never":
+		lipgloss.SetColorProfile(termenv.Ascii)
+		// "auto" - let lipgloss use its default TTY-based detection
 	}
 }

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -75,7 +75,7 @@ func (f *legacyFormatter) Format(input io.Reader) error {
 	// Start scanner goroutine that reads input and writes to pipe
 	scanErr := make(chan error, 1)
 	go func() {
-		defer pw.Close()
+		defer func() { _ = pw.Close() }()
 
 		scanner := bufio.NewScanner(input)
 		const maxScannerBuffer = 1024 * 1024

--- a/internal/formatter/styles.go
+++ b/internal/formatter/styles.go
@@ -1,11 +1,10 @@
 package formatter
 
-import (
-	"github.com/charmbracelet/lipgloss"
-	"github.com/martinemde/skillet/internal/color"
-)
+import "github.com/charmbracelet/lipgloss"
 
-// Icon and style definitions for terminal output
+// Icon and style definitions for terminal output.
+// Colors are automatically handled by the global lipgloss color profile
+// which is configured by color.ConfigureColorProfile() based on --color flag.
 var (
 	successIcon = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).SetString("✓")
 	errorIcon   = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).SetString("✗")
@@ -27,21 +26,3 @@ var (
 			MarginTop(0).
 			MarginBottom(1)
 )
-
-// applyColorToIcon applies or removes color from an icon style based on color mode
-func applyColorToIcon(icon lipgloss.Style, colorMode string) lipgloss.Style {
-	if !color.ShouldUseColors(colorMode) {
-		// Return a plain style without color
-		return lipgloss.NewStyle().SetString(icon.Value())
-	}
-	return icon
-}
-
-// applyColorToStyle applies or removes color from a style based on color mode
-func applyColorToStyle(style lipgloss.Style, colorMode string) lipgloss.Style {
-	if !color.ShouldUseColors(colorMode) {
-		// Return a plain style without color, but preserve other properties like margin
-		return lipgloss.NewStyle()
-	}
-	return style
-}

--- a/internal/formatter/terminal.go
+++ b/internal/formatter/terminal.go
@@ -7,7 +7,6 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
-	"github.com/martinemde/skillet/internal/color"
 )
 
 // TerminalFormatter formats output for normal (non-verbose) terminal mode
@@ -53,11 +52,10 @@ func (f *TerminalFormatter) Format(events <-chan StreamEvent) error {
 
 // printSystemInit prints the system initialization message
 func (f *TerminalFormatter) printSystemInit(data SystemInitData) {
-	icon := applyColorToIcon(successIcon, f.color)
 	if data.SkillName != "" {
-		_, _ = fmt.Fprintf(f.output, "%s Starting %s\n", icon.String(), data.SkillName)
+		_, _ = fmt.Fprintf(f.output, "%s Starting %s\n", successIcon.String(), data.SkillName)
 	} else {
-		_, _ = fmt.Fprintf(f.output, "%s Starting\n", icon.String())
+		_, _ = fmt.Fprintf(f.output, "%s Starting\n", successIcon.String())
 	}
 }
 
@@ -77,7 +75,6 @@ func (f *TerminalFormatter) printToolOperation(tool ToolOperation) {
 	case "empty":
 		icon = emptyIcon
 	}
-	icon = applyColorToIcon(icon, f.color)
 
 	// Format tool line
 	line := fmt.Sprintf("%s %s", icon.String(), tool.Name)
@@ -85,8 +82,7 @@ func (f *TerminalFormatter) printToolOperation(tool ToolOperation) {
 		line += " " + tool.Target
 	}
 	if tool.Status == "error" && tool.Error != "" {
-		style := applyColorToStyle(dimStyle, f.color)
-		line += style.Render(fmt.Sprintf(" (%s)", tool.Error))
+		line += dimStyle.Render(fmt.Sprintf(" (%s)", tool.Error))
 	}
 	_, _ = fmt.Fprintln(f.output, line)
 }
@@ -107,8 +103,7 @@ func (f *TerminalFormatter) printTodoStatusLines(tool ToolOperation) {
 
 		// Show the most recently completed task first (dimmed with ☒)
 		if lastCompleted != "" {
-			style := applyColorToStyle(dimStyle, f.color)
-			_, _ = fmt.Fprintf(f.output, "%s\n", style.Render("☒ "+lastCompleted))
+			_, _ = fmt.Fprintf(f.output, "%s\n", dimStyle.Render("☒ "+lastCompleted))
 		}
 
 		// Show remaining tasks
@@ -125,8 +120,7 @@ func (f *TerminalFormatter) printTodoStatusLines(tool ToolOperation) {
 					_, _ = fmt.Fprintf(f.output, "☐ %s\n", content)
 				} else {
 					// Pending: dimmed with empty checkbox
-					style := applyColorToStyle(dimStyle, f.color)
-					_, _ = fmt.Fprintf(f.output, "%s\n", style.Render("☐ "+content))
+					_, _ = fmt.Fprintf(f.output, "%s\n", dimStyle.Render("☐ "+content))
 				}
 			}
 		}
@@ -144,11 +138,9 @@ func (f *TerminalFormatter) printFinalResult(data FinalResultData) {
 	// Print completion status
 	_, _ = fmt.Fprintln(f.output)
 	if data.IsError {
-		icon := applyColorToIcon(errorIcon, f.color)
-		_, _ = fmt.Fprintln(f.output, icon.String()+" Failed")
+		_, _ = fmt.Fprintln(f.output, errorIcon.String()+" Failed")
 	} else {
-		icon := applyColorToIcon(successIcon, f.color)
-		_, _ = fmt.Fprintf(f.output, "%s Completed in %.1fs\n", icon.String(), data.Elapsed.Seconds())
+		_, _ = fmt.Fprintf(f.output, "%s Completed in %.1fs\n", successIcon.String(), data.Elapsed.Seconds())
 	}
 }
 
@@ -184,19 +176,14 @@ func (f *TerminalFormatter) printUsage(usage *Usage) {
 		}
 	}
 
-	// Create styled table with color support
-	borderStyle := lipgloss.NewStyle()
-	if color.ShouldUseColors(f.color) {
-		borderStyle = borderStyle.Foreground(lipgloss.Color("8"))
-	}
-
+	// Create styled table - colors are handled by global lipgloss profile
 	t := table.New().
 		Border(lipgloss.NormalBorder()).
-		BorderStyle(borderStyle).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("8"))).
 		StyleFunc(func(row, col int) lipgloss.Style {
 			if col == 0 {
 				// Metric name column - dim style
-				return applyColorToStyle(dimStyle, f.color)
+				return dimStyle
 			}
 			// Value column - normal style
 			return lipgloss.NewStyle()


### PR DESCRIPTION
Lipgloss and glamour have internal TTY detection that automatically strips ANSI color codes when stdout is piped, regardless of what the application code requests. This made `--color=always` ineffective.

The fix uses `lipgloss.SetColorProfile()` to configure the global color profile early, before any rendering:

- "always": Uses `termenv.EnvColorProfile()` which detects terminal color capabilities from environment variables (COLORTERM, TERM) without checking if stdout is a TTY. This respects the terminal's actual color support while allowing colors through pipes.

- "never": Forces `termenv.Ascii` to disable all colors globally.

- "auto": Lets lipgloss use its default TTY-based detection.

For glamour markdown rendering, `--color=always` now also passes `WithColorProfile(termenv.TrueColor)` to force colors.

This simplification also removes the redundant `applyColorToIcon` and `applyColorToStyle` wrapper functions since the global profile now handles color stripping automatically.